### PR TITLE
fix model buffer read offset

### DIFF
--- a/src/filestore/stores/model-store.ts
+++ b/src/filestore/stores/model-store.ts
@@ -554,15 +554,27 @@ export class ModelStore {
             const mask = vertexDirectionOffsetBuffer.get('BYTE', 'UNSIGNED');
             let xOffset = 0;
             if ((mask & 0x1) != 0) {
-                xOffset = xDataOffsetBuffer.get('SMART', 'UNSIGNED');
+                try {
+                    xOffset = xDataOffsetBuffer.get('SMART', 'UNSIGNED');
+                } catch {
+                    console.warn('Tried to read out of range xOffset for object', id);
+                }
             }
             let yOffset = 0;
             if ((mask & 0x2) != 0) {
-                yOffset = yDataOffsetBuffer.get('SMART', 'UNSIGNED');
+                try {
+                    yOffset = yDataOffsetBuffer.get('SMART', 'UNSIGNED');
+                } catch {
+                    console.warn('Tried to read out of range yOffset for object', id);
+                }
             }
             let zOffset = 0;
             if ((mask & 0x4) != 0) {
-                zOffset = zDataOffsetBuffer.get('SMART', 'UNSIGNED');
+                try {
+                    zOffset = zDataOffsetBuffer.get('SMART', 'UNSIGNED');
+                } catch {
+                    console.warn('Tried to read out of range zOffset for object', id);
+                }
             }
             rsModel.verticesX[i] = baseOffsetX + xOffset;
             rsModel.verticesY[i] = baseOffsetY + yOffset;


### PR DESCRIPTION
a lot of models were not rendering at all because the buffer reader was trying to read from an index that exceeded the data length. The error was `RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range.`

Since the offsets are defaulted to 0, we can just run the buffer read in a try catch block, and show a warning for now. I believe this is harmless, because if the reader exceeds the data length, the offset is most likely meant to be 0 anyways.